### PR TITLE
replace Arrays.equals() to MessageDigest.isEqual to block timing attacks vulnerability

### DIFF
--- a/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/TPMTHA.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/data/attestation/statement/TPMTHA.java
@@ -23,6 +23,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -57,7 +58,7 @@ public class TPMTHA implements Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         TPMTHA tpmtha = (TPMTHA) o;
         return hashAlg == tpmtha.hashAlg &&
-                Arrays.equals(digest, tpmtha.digest);
+                MessageDigest.isEqual(digest, tpmtha.digest);
     }
 
     @Override

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/androidsafetynet/AndroidSafetyNetAttestationStatementValidator.java
@@ -31,9 +31,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Objects;
 
 public class AndroidSafetyNetAttestationStatementValidator extends AbstractStatementValidator<AndroidSafetyNetAttestationStatement> {
@@ -162,7 +162,7 @@ public class AndroidSafetyNetAttestationStatementValidator extends AbstractState
         ByteBuffer buffer = ByteBuffer.allocate(authenticatorData.length + clientDataHash.length);
         byte[] data = buffer.put(authenticatorData).put(clientDataHash).array();
         byte[] hash = MessageDigestUtil.createSHA256().digest(data);
-        if (!Arrays.equals(hash, Base64Util.decode(nonce))) {
+        if (!MessageDigest.isEqual(hash, Base64Util.decode(nonce))) {
             throw new BadAttestationStatementException("Nonce in the Android safetynet response doesn't match.");
         }
     }

--- a/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/tpm/TPMAttestationStatementValidator.java
+++ b/webauthn4j-core/src/main/java/com/webauthn4j/validator/attestation/statement/tpm/TPMAttestationStatementValidator.java
@@ -127,7 +127,7 @@ public class TPMAttestationStatementValidator extends AbstractStatementValidator
         algJcaName = getAlgJcaName(hashAlg);
 
         byte[] pubAreaDigest = MessageDigestUtil.createMessageDigest(algJcaName).digest(pubArea.getBytes());
-        if (!Arrays.equals(pubAreaDigest, certifyInfo.getName().getDigest())) {
+        if (!MessageDigest.isEqual(pubAreaDigest, certifyInfo.getName().getDigest())) {
             throw new BadAttestationStatementException("hash of `attested` doesn't match with name field of certifyInfo");
         }
 

--- a/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMdsMetadataItemsProvider.java
+++ b/webauthn4j-metadata/src/main/java/com/webauthn4j/metadata/FidoMdsMetadataItemsProvider.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.MessageDigest;
 import java.security.cert.*;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -222,7 +223,7 @@ public class FidoMdsMetadataItemsProvider implements MetadataItemsProvider {
         String metadataStatementBase64url = httpClient.fetch(uriWithToken);
         String metadataStatementStr = new String(Base64UrlUtil.decode(metadataStatementBase64url));
         byte[] hash = MessageDigestUtil.createSHA256().digest(metadataStatementBase64url.getBytes(StandardCharsets.UTF_8));
-        if (!Arrays.equals(hash, expectedHash)) {
+        if (!MessageDigest.isEqual(hash, expectedHash)) {
             throw new MDSException("Hash of metadataStatement doesn't match");
         }
         MetadataStatement metadataStatement = jsonConverter.readValue(metadataStatementStr, MetadataStatement.class);


### PR DESCRIPTION
Fix for the 4 security issues from snyk code analysis 

<img width="1131" alt="Screen Shot 2021-08-12 at 16 03 50" src="https://user-images.githubusercontent.com/8987031/129211439-ae7530d6-f62d-42d5-8656-de6e39046d75.png">

<img width="1129" alt="Screen Shot 2021-08-12 at 16 08 35" src="https://user-images.githubusercontent.com/8987031/129211938-986fd376-94e2-4781-9d8c-1bfba70a63f0.png">

<img width="1130" alt="Screen Shot 2021-08-12 at 16 08 45" src="https://user-images.githubusercontent.com/8987031/129211954-b5f65b50-b3b1-4154-9123-b57f548d5ca6.png">

<img width="1123" alt="Screen Shot 2021-08-12 at 16 08 51" src="https://user-images.githubusercontent.com/8987031/129211963-655394d9-d701-4e49-8e7c-15026d11daf8.png">

<img width="1119" alt="Screen Shot 2021-08-12 at 16 08 40" src="https://user-images.githubusercontent.com/8987031/129211977-48d33bd0-b19e-4736-bee8-1492e7d8dcca.png">

